### PR TITLE
Format imports to follow pep-8

### DIFF
--- a/cogs/sample.py
+++ b/cogs/sample.py
@@ -1,6 +1,6 @@
 import discord
-from discord.ext import commands
 from discord import app_commands
+from discord.ext import commands
 
 
 class Sample(commands.Cog):

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+
 import discord
 from discord.ext import commands
 


### PR DESCRIPTION
I know that I am being annoyingly nit-picky here lol but I have realized that you like to follow standards and conventions and format your code based on those. For that reason, I have just changed the import lines in main.py and cogs/sample.py to follow [PEP 8 recommendations](https://peps.python.org/pep-0008/).

> Imports should be grouped in the following order:
>
> 1. Standard library imports.
> 2. Related third party imports.
> 3. Local application/library specific imports.
>
> You should put a blank line between each group of imports.

It's fine even if you don't accept this PR because I know that this one is kinda annoying lol but meh, I also like to nit-pick :^)